### PR TITLE
Fix-39-Creds-on-Start

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -77,11 +76,12 @@ func (logConfig *CollectorConfig) SetCreds() error {
 		return fmt.Errorf("%s environment variable is not set", ENV_PARSEABLE_SERVER_URL)
 	}
 	logConfig.Username, ok = os.LookupEnv(ENV_PARSEABLE_SERVER_USERNAME)
-	if ok {
-		logConfig.Password, ok = os.LookupEnv(ENV_PARSEABLE_SERVER_PASSWORD)
-		if !ok {
-			log.Info("Parseable credentials are not set as environment variables. Sending unauthenticated requests to Parseable server.")
-		}
+	if !ok {
+		return fmt.Errorf("Parseable credentials are not set as environment variables")
+	}
+	logConfig.Password, ok = os.LookupEnv(ENV_PARSEABLE_SERVER_PASSWORD)
+	if !ok {
+		return fmt.Errorf("Parseable credentials are not set as environment variables")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Kube Collector be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #39 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while using kube collector. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new kube-collector works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing kube collector with parseable server . If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`